### PR TITLE
Change android resolution of packages

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -4,22 +4,6 @@ project(react-native-matrix-rust-sdk)
 set (CMAKE_VERBOSE_MAKEFILE ON)
 set (CMAKE_CXX_STANDARD 14)
 
-
-if(NOT DEFINED REACT_NATIVE_PATH)
-    set(REACT_NATIVE_PATH "../node_modules/react-native")
-endif()
-
-if(NOT DEFINED REACT_ANDROID_DIR)
-    set(REACT_ANDROID_DIR "${REACT_NATIVE_PATH}/ReactAndroid")
-endif()
-
-include_directories(
-#     ${REACT_NATIVE_PATH}/React
-#     ${REACT_NATIVE_PATH}/React/Base
-#     ${REACT_NATIVE_PATH}/ReactCommon     # API
-    ${REACT_NATIVE_PATH}/ReactCommon/jsi # API/src
-)
-
 # Specifies a path to native header files.
 include_directories(
     ../cpp
@@ -31,6 +15,13 @@ add_library(
     ${CMAKE_PROJECT_NAME} SHARED
     ../cpp/react-native-matrix-rust-sdk.cpp
     cpp-adapter.cpp
+)
+
+find_package(ReactAndroid REQUIRED CONFIG)
+
+target_link_libraries(
+  ${CMAKE_PROJECT_NAME}
+  ReactAndroid::jsi
 )
 
 # link_libraries(jsi)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -55,9 +55,13 @@ android {
     targetSdkVersion getExtOrIntegerDefault("targetSdkVersion")
     buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
 
+    buildFeatures {
+      prefab true
+    }
     externalNativeBuild {
       cmake {
         cppFlags "-O2 -frtti -fexceptions -Wall -fstack-protector-all"
+        arguments '-DANDROID_STL=c++_shared'
       }
     }
   }


### PR DESCRIPTION
Rather than rely on hardcoded relative paths, use other CMake features to find the package and link to it directly.

After hacking at it to make it work, this seemed to be the minimal set of changes needed.  Unsure if this actually belongs over in uniffi-bindgen instead at this point.